### PR TITLE
Add more robustness to the exporter

### DIFF
--- a/vespa-exporter.py
+++ b/vespa-exporter.py
@@ -13,6 +13,7 @@ http_port = 9426
 config_server = os.getenv('VESPA_CONFIGSERVER', 'localhost:19071')
 configurl = 'http://' + config_server + '/config/v2/tenant/default/application/default/cloud.config.model/client'
 prom_metrics = {}
+endpoints = {}
 
 first_cap_re = re.compile('(.)([A-Z][a-z]+)')
 all_cap_re = re.compile('([a-z0-9])([A-Z])')
@@ -24,27 +25,29 @@ def camelcase_convert(name):
 
 
 def get_metrics():
+    global endpoints
     try:
         response = requests.get(configurl)
+        
+        try:
+            model = json.loads(response.text)
+        except ValueError:
+            logger.error('JSON parse failed.')
+            raise ValueError
+
+        endpoints = {}
+        for host in model['hosts']:
+            for service in host['services']:
+                for port in service['ports']:
+                    if 'http' in port['tags'].split(' ') and 'state' in port['tags'].split(' '):
+                        if service['name'] in endpoints:
+                            endpoints[service['name']].append(host['name']+':'+str(port['number']))
+                        else:
+                            endpoints[service['name']] = [host['name']+':'+str(port['number'])]
     except requests.exceptions.RequestException as e:
-        logger.error('Request failed: %s', e)
-        raise ValueError
-
-    try:
-        model = json.loads(response.text)
-    except ValueError:
-        logger.error('JSON parse failed.')
-        raise ValueError
-
-    endpoints = {}
-    for host in model['hosts']:
-        for service in host['services']:
-            for port in service['ports']:
-                if 'http' in port['tags'].split(' ') and 'state' in port['tags'].split(' '):
-                    if service['name'] in endpoints:
-                        endpoints[service['name']].append(host['name']+':'+str(port['number']))
-                    else:
-                        endpoints[service['name']] = [host['name']+':'+str(port['number'])]
+        logger.error('Request failed (could not update infos from cluster controller %s): %s', config_server, e)
+        if not endpoints:
+            raise ValueError
 
     for s in endpoints['searchnode']:
         get_searchnode_metrics(s)
@@ -58,56 +61,54 @@ def get_searchnode_metrics(hostport):
     url = 'http://' + host + ':' + port + '/state/v1/metrics'
     try:
         response = requests.get(url)
-    except requests.exceptions.RequestException as e:
-        logger.error('Request failed: %s', e)
-        raise ValueError
 
-    try:
-        m = json.loads(response.text)
-    except ValueError:
-        logger.error('JSON parse failed.')
-        raise ValueError
+        try:
+            m = json.loads(response.text)
+        except ValueError:
+            logger.error('JSON parse failed.')
+            raise ValueError
 
-    status_code = m['status']['code']
-    name = service + '_' + 'status_code_up'
-    if name not in prom_metrics:
-        prom_metrics[name] = Gauge(name, 'Status code up?', ['host'])
-    if status_code == 'up':
-        value = 1
-    else:
-        value = 0
-    prom_metrics[name].labels(host=host).set(value)
-
-    snapshot_to = m['metrics']['snapshot']['to']
-    name = service + '_' + 'snapshot_to'
-    if name not in prom_metrics:
-        prom_metrics[name] = Gauge(name, 'Snapshot to timestamp', ['host'])
-    prom_metrics[name].labels(host=host).set(snapshot_to)
-
-    snapshot_from = m['metrics']['snapshot']['from']
-    name = service + '_' + 'snapshot_from'
-    if name not in prom_metrics:
-        prom_metrics[name] = Gauge(name, 'Snapshot from timestamp', ['host'])
-    prom_metrics[name].labels(host=host).set(snapshot_from)
-
-    for v in m['metrics']['values']:
-        name = service + '_' + v['name']
-        name = name.replace('.', '_').replace('-', '_')
-        name = name.replace('[', '').replace(']', '')
-        desc = v['description']
-        labels = ['aggregation', 'host']
-        labelvalues = {}
-        labelvalues['host'] = host
-        for d in ['documenttype', 'field', 'disk', 'operantiontype']:
-            if d in v['dimensions']:
-                labels.append(d)
-                labelvalues[d] = v['dimensions'][d]
+        status_code = m['status']['code']
+        name = service + '_' + 'status_code_up'
         if name not in prom_metrics:
-            prom_metrics[name] = Gauge(name, desc, labels)
-        for agg in v['values']:
-            labelvalues['aggregation'] = agg
-            prom_metrics[name].labels(**labelvalues).set(v['values'][agg])
+            prom_metrics[name] = Gauge(name, 'Status code up?', ['host'])
+        if status_code == 'up':
+            value = 1
+        else:
+            value = 0
+        prom_metrics[name].labels(host=host).set(value)
 
+        snapshot_to = m['metrics']['snapshot']['to']
+        name = service + '_' + 'snapshot_to'
+        if name not in prom_metrics:
+            prom_metrics[name] = Gauge(name, 'Snapshot to timestamp', ['host'])
+        prom_metrics[name].labels(host=host).set(snapshot_to)
+
+        snapshot_from = m['metrics']['snapshot']['from']
+        name = service + '_' + 'snapshot_from'
+        if name not in prom_metrics:
+            prom_metrics[name] = Gauge(name, 'Snapshot from timestamp', ['host'])
+        prom_metrics[name].labels(host=host).set(snapshot_from)
+
+        for v in m['metrics']['values']:
+            name = service + '_' + v['name']
+            name = name.replace('.', '_').replace('-', '_')
+            name = name.replace('[', '').replace(']', '')
+            desc = v['description']
+            labels = ['aggregation', 'host']
+            labelvalues = {}
+            labelvalues['host'] = host
+            for d in ['documenttype', 'field', 'disk', 'operantiontype']:
+                if d in v['dimensions']:
+                    labels.append(d)
+                    labelvalues[d] = v['dimensions'][d]
+            if name not in prom_metrics:
+                prom_metrics[name] = Gauge(name, desc, labels)
+            for agg in v['values']:
+                labelvalues['aggregation'] = agg
+                prom_metrics[name].labels(**labelvalues).set(v['values'][agg])
+    except requests.exceptions.RequestException as e:
+        logger.error('Request failed (could not update metrics from endpoint %s): %s', hostport, e)
 
 def get_container_metrics(hostport):
     service = 'vespa_container'
@@ -116,34 +117,34 @@ def get_container_metrics(hostport):
 
     try:
         response = requests.get(url)
+
+        try:
+            m = json.loads(response.text)
+        except ValueError:
+            logger.error('JSON parse failed.')
+            raise ValueError
+
+        for v in m['metrics']['values']:
+            name = service + '_' + camelcase_convert(v['name'])
+            name = name.replace('.', '_').replace('-', '_')
+            name = name.replace('[', '').replace(']', '')
+            desc = name
+            labels = ['aggregation', 'host']
+            labelvalues = {}
+            labelvalues['host'] = host
+            if 'dimensions' in v:
+                for d in ['chain', 'handler', 'api', 'operation', 'status', 'serverName', 'serverPort']:
+                    if d in v['dimensions']:
+                        labels.append(d.lower())
+                        labelvalues[d.lower()] = v['dimensions'][d]
+            if name not in prom_metrics:
+                prom_metrics[name] = Gauge(name, desc, labels)
+            for agg in v['values']:
+                labelvalues['aggregation'] = agg
+                prom_metrics[name].labels(**labelvalues).set(v['values'][agg])
+
     except requests.exceptions.RequestException as e:
-        logger.error('Request failed: %s', e)
-        raise ValueError
-
-    try:
-        m = json.loads(response.text)
-    except ValueError:
-        logger.error('JSON parse failed.')
-        raise ValueError
-
-    for v in m['metrics']['values']:
-        name = service + '_' + camelcase_convert(v['name'])
-        name = name.replace('.', '_').replace('-', '_')
-        name = name.replace('[', '').replace(']', '')
-        desc = name
-        labels = ['aggregation', 'host']
-        labelvalues = {}
-        labelvalues['host'] = host
-        if 'dimensions' in v:
-            for d in ['chain', 'handler', 'api', 'operation', 'status', 'serverName', 'serverPort']:
-                if d in v['dimensions']:
-                    labels.append(d.lower())
-                    labelvalues[d.lower()] = v['dimensions'][d]
-        if name not in prom_metrics:
-            prom_metrics[name] = Gauge(name, desc, labels)
-        for agg in v['values']:
-            labelvalues['aggregation'] = agg
-            prom_metrics[name].labels(**labelvalues).set(v['values'][agg])
+        logger.error('Request failed (could not update metrics from endpoint %s): %s', hostport, e)
 
 
 def main():


### PR DESCRIPTION
When using the exporter I realized it would crash if some of the nodes listed in the cluster controller were down. So I removed the **raise** to not crash anymore, so that the exporter is still able to send the metrics of the other nodes still up.
I also realized that if the cluster controller went down, the exporter would **raise** and crash too. I changed this behaviour so that it would keep trying to get the metrics from the last known nodes and only stop if it does not know any node of the cluster.