### PR TITLE
Allow support for more Vespa services

### DIFF
--- a/vespa-exporter.py
+++ b/vespa-exporter.py
@@ -49,14 +49,15 @@ def get_metrics():
         if not endpoints:
             raise ValueError
 
-    for s in endpoints['searchnode']:
-        get_searchnode_metrics(s)
+    for service_type in ['searchnode', 'distributor']:
+        for service_hostport in endpoints[service_type]:
+            get_standardservice_metrics(service_type, service_hostport)
     for c in endpoints['container']:
         get_container_metrics(c)
 
 
-def get_searchnode_metrics(hostport):
-    service = 'vespa_searchnode'
+def get_standardservice_metrics(service_type, hostport):
+    service = 'vespa_' + service_type
     (host, port) = hostport.split(':')
     url = 'http://' + host + ':' + port + '/state/v1/metrics'
     try:


### PR DESCRIPTION
This allows to fetch metrics from more services than only "searchnode" and "container". For now I only added "distributor", but the changes should allow more services metrics to be exported.

As far as I've seen the metrics from the other services, they should be parsed the same way as the "searchnode" ones. That's why I used the method `get_searchnode_metrics` but renamed it `get_standardservice_metrics` in order to reflect the fact it is used for all services which are formatted the same way. And it now also takes as parameter the type of service it exports so that the name of the metric tells from which service it comes (not only "searchnode" anymore).