### PR TITLE
 Set status code to zero when a service is unreachable

### DIFF
--- a/vespa-exporter.py
+++ b/vespa-exporter.py
@@ -109,6 +109,7 @@ def get_standardservice_metrics(service_type, hostport):
                 labelvalues['aggregation'] = agg
                 prom_metrics[name].labels(**labelvalues).set(v['values'][agg])
     except requests.exceptions.RequestException as e:
+        prom_metrics[service + '_status_code_up'].labels(host=hostport).set(0)
         logger.error('Request failed (could not update metrics from endpoint %s): %s', hostport, e)
 
 def get_container_metrics(hostport):


### PR DESCRIPTION
When a service is unreachable we need to set its status_code metric to zero.

Until now, when we started the exporter and a service was already down, the metric did just not appear and we might not notice that it was down at startup.

And when a service got down while the exporter was already running, the "status" metric would keep its last value (like all the metrics in this situation), but if there is one metric that we should update when we can not contact the service, it's this one.

Now we can determine when a service was down and consider all the metrics prompted during that period as just the last known value before the interruption. Before that, the only way to know a service was down was to not see the metrics varying anymore.