### PR TITLE
Update to Python 3 + update dependencies + update Docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,17 @@
-FROM alpine:3.5
+FROM alpine:3.8
 
 RUN apk --update upgrade
 RUN apk add --no-cache --update \
-    python \
-    py-pip \
-  && pip install --upgrade pip \
-  && pip install virtualenv \
+    python3 \
+  && pip3 install --upgrade pip \
+  && pip3 install virtualenv \
   && virtualenv /env
 
 WORKDIR /app
 COPY requirements.txt /app/
 
-RUN /env/bin/pip install -r requirements.txt
+RUN /env/bin/pip3 install -r requirements.txt
 
 COPY vespa-exporter.py /app/
 
-CMD ["/env/bin/python", "/app/vespa-exporter.py"]
+CMD ["/env/bin/python3", "/app/vespa-exporter.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.20.0
-prometheus_client==0.1.0
+requests==2.21.0
+prometheus_client==0.5.0


### PR DESCRIPTION
Update to Python 3 to avoid the following deprecation message since code is already compatible:
```
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
```

Also update the dependencies and the base Docker image of alpine.

I used it and did not notice any break after those updates.