### PR TITLE
Refactorise code + separate metric for failed metrics retrieval and Vespa status codes.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.10
 
 RUN apk --update upgrade
 RUN apk add --no-cache --update \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.21.0
-prometheus_client==0.5.0
+requests==2.22.0
+prometheus_client==0.7.0


### PR DESCRIPTION
- Factorisation of the code which exposes status code and snapshot metrics
- Add a metric (`vespa_application_generation`) which exposes the application generation deployed
- Add a metric (**service_name**`_exporter_http_fetch_failed`) which is set to 1 if the exporter fails to retrieve the metrics for this service and 0 otherwise. Until now, we used to set the status code of the service to down when we did not retrieve its metrics. This could lead to wrong diagnostics.
- Update requirements and Docker base image

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
